### PR TITLE
Graph improvements

### DIFF
--- a/Infini-iOS.xcodeproj/project.pbxproj
+++ b/Infini-iOS.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		264DB80B26C62ED600E812C3 /* SideMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264DB80A26C62ED600E812C3 /* SideMenu.swift */; };
 		264DB80D26C633CF00E812C3 /* PageSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264DB80C26C633CF00E812C3 /* PageSwitcher.swift */; };
 		266F53E426F7FCA6007481A6 /* ChartManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E326F7FCA6007481A6 /* ChartManager.swift */; };
+		266F53E626FA7676007481A6 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E526FA7676007481A6 /* HomeScreen.swift */; };
+		266F53EA26FA91F3007481A6 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E926FA91F3007481A6 /* DeviceInfo.swift */; };
 		2675CA5726DC447500967E4D /* SheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5626DC447500967E4D /* SheetManager.swift */; };
 		2675CA5A26DC81AA00967E4D /* DFUComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5926DC81AA00967E4D /* DFUComplete.swift */; };
 		26A6314D26BEFD2C005AE404 /* MusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A6314C26BEFD2C005AE404 /* MusicController.swift */; };
@@ -106,6 +108,8 @@
 		264DB80C26C633CF00E812C3 /* PageSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSwitcher.swift; sourceTree = "<group>"; };
 		2656FD9A26D1B30C001EF20C /* PrivacyPolicy.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PrivacyPolicy.md; sourceTree = "<group>"; };
 		266F53E326F7FCA6007481A6 /* ChartManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartManager.swift; sourceTree = "<group>"; };
+		266F53E526FA7676007481A6 /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
+		266F53E926FA91F3007481A6 /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		2675CA5626DC447500967E4D /* SheetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetManager.swift; sourceTree = "<group>"; };
 		2675CA5926DC81AA00967E4D /* DFUComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DFUComplete.swift; sourceTree = "<group>"; };
 		26A6314C26BEFD2C005AE404 /* MusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicController.swift; sourceTree = "<group>"; };
@@ -166,8 +170,8 @@
 			children = (
 				263B20B426CD673900676BF0 /* StatusViewTabs.swift */,
 				263B20B926CDF13400676BF0 /* HeartChart.swift */,
-				266F53E326F7FCA6007481A6 /* ChartManager.swift */,
 				263B20BB26CDF20400676BF0 /* BatteryChart.swift */,
+				266F53E326F7FCA6007481A6 /* ChartManager.swift */,
 			);
 			path = "Status View Components";
 			sourceTree = "<group>";
@@ -259,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				2632388B26F265B100D72B43 /* MainView.swift */,
+				266F53E526FA7676007481A6 /* HomeScreen.swift */,
 				264DB80A26C62ED600E812C3 /* SideMenu.swift */,
 				26A6316226C4C6D6005AE404 /* BLEConnectView.swift */,
 				26F426EE26C72D7D00D0866B /* BLEStatusView.swift */,
@@ -312,6 +317,7 @@
 				26D7816426C9EB3800BBF555 /* BLEDelegates.swift */,
 				26D7816626C9EC3100BBF555 /* BLEManagerExtensions.swift */,
 				2644261126DC093D009BD54A /* SetTime.swift */,
+				266F53E926FA91F3007481A6 /* DeviceInfo.swift */,
 			);
 			path = BLE;
 			sourceTree = "<group>";
@@ -513,12 +519,14 @@
 				26D7817526CAB79200BBF555 /* PhoneNotificationsView.swift in Sources */,
 				263B20BC26CDF20400676BF0 /* BatteryChart.swift in Sources */,
 				2644261226DC093D009BD54A /* SetTime.swift in Sources */,
+				266F53E626FA7676007481A6 /* HomeScreen.swift in Sources */,
 				263B20B526CD673900676BF0 /* StatusViewTabs.swift in Sources */,
 				26D7816E26CA003B00BBF555 /* SettingsFunctions.swift in Sources */,
 				26A6316326C4C6D6005AE404 /* BLEConnectView.swift in Sources */,
 				26D7816526C9EB3800BBF555 /* BLEDelegates.swift in Sources */,
 				26A6315B26C49841005AE404 /* DFU.swift in Sources */,
 				26D7817A26CAD19F00BBF555 /* ColorPalette.swift in Sources */,
+				266F53EA26FA91F3007481A6 /* DeviceInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Infini-iOS.xcodeproj/project.pbxproj
+++ b/Infini-iOS.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		2632388C26F265B100D72B43 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2632388B26F265B100D72B43 /* MainView.swift */; };
 		2632388E26F297CB00D72B43 /* OnboardingBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2632388D26F297CB00D72B43 /* OnboardingBody.swift */; };
 		2632389026F2980A00D72B43 /* OnboardingDismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2632388F26F2980A00D72B43 /* OnboardingDismissButton.swift */; };
-		263B20B526CD673900676BF0 /* StatusViewTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263B20B426CD673900676BF0 /* StatusViewTabs.swift */; };
+		263B20B526CD673900676BF0 /* ChartTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263B20B426CD673900676BF0 /* ChartTabs.swift */; };
 		263B20BA26CDF13400676BF0 /* HeartChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263B20B926CDF13400676BF0 /* HeartChart.swift */; };
 		263B20BC26CDF20400676BF0 /* BatteryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263B20BB26CDF20400676BF0 /* BatteryChart.swift */; };
 		263B20C526CEB46800676BF0 /* SwiftUICharts in Frameworks */ = {isa = PBXBuildFile; productRef = 263B20C426CEB46800676BF0 /* SwiftUICharts */; };
@@ -37,6 +37,7 @@
 		266F53E426F7FCA6007481A6 /* ChartManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E326F7FCA6007481A6 /* ChartManager.swift */; };
 		266F53E626FA7676007481A6 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E526FA7676007481A6 /* HomeScreen.swift */; };
 		266F53EA26FA91F3007481A6 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E926FA91F3007481A6 /* DeviceInfo.swift */; };
+		266F53EC26FAABE7007481A6 /* TimeRangeTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53EB26FAABE7007481A6 /* TimeRangeTabs.swift */; };
 		2675CA5726DC447500967E4D /* SheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5626DC447500967E4D /* SheetManager.swift */; };
 		2675CA5A26DC81AA00967E4D /* DFUComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5926DC81AA00967E4D /* DFUComplete.swift */; };
 		26A6314D26BEFD2C005AE404 /* MusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A6314C26BEFD2C005AE404 /* MusicController.swift */; };
@@ -82,7 +83,7 @@
 		2632388B26F265B100D72B43 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		2632388D26F297CB00D72B43 /* OnboardingBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBody.swift; sourceTree = "<group>"; };
 		2632388F26F2980A00D72B43 /* OnboardingDismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDismissButton.swift; sourceTree = "<group>"; };
-		263B20B426CD673900676BF0 /* StatusViewTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusViewTabs.swift; sourceTree = "<group>"; };
+		263B20B426CD673900676BF0 /* ChartTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartTabs.swift; sourceTree = "<group>"; };
 		263B20B926CDF13400676BF0 /* HeartChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartChart.swift; sourceTree = "<group>"; };
 		263B20BB26CDF20400676BF0 /* BatteryChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryChart.swift; sourceTree = "<group>"; };
 		263B20C626CF07BB00676BF0 /* DFUProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DFUProgressBar.swift; sourceTree = "<group>"; };
@@ -110,6 +111,7 @@
 		266F53E326F7FCA6007481A6 /* ChartManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartManager.swift; sourceTree = "<group>"; };
 		266F53E526FA7676007481A6 /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
 		266F53E926FA91F3007481A6 /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
+		266F53EB26FAABE7007481A6 /* TimeRangeTabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeRangeTabs.swift; sourceTree = "<group>"; };
 		2675CA5626DC447500967E4D /* SheetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetManager.swift; sourceTree = "<group>"; };
 		2675CA5926DC81AA00967E4D /* DFUComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DFUComplete.swift; sourceTree = "<group>"; };
 		26A6314C26BEFD2C005AE404 /* MusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicController.swift; sourceTree = "<group>"; };
@@ -168,7 +170,8 @@
 		263B20B626CD673D00676BF0 /* Status View Components */ = {
 			isa = PBXGroup;
 			children = (
-				263B20B426CD673900676BF0 /* StatusViewTabs.swift */,
+				266F53EB26FAABE7007481A6 /* TimeRangeTabs.swift */,
+				263B20B426CD673900676BF0 /* ChartTabs.swift */,
 				263B20B926CDF13400676BF0 /* HeartChart.swift */,
 				263B20BB26CDF20400676BF0 /* BatteryChart.swift */,
 				266F53E326F7FCA6007481A6 /* ChartManager.swift */,
@@ -511,6 +514,7 @@
 				264BFE4226BC51CE0050A223 /* Infini_iOSApp.swift in Sources */,
 				2675CA5726DC447500967E4D /* SheetManager.swift in Sources */,
 				26318B1626CB27E70036051E /* Infini_iOS.xcdatamodeld in Sources */,
+				266F53EC26FAABE7007481A6 /* TimeRangeTabs.swift in Sources */,
 				264BFE7626BC52720050A223 /* HexStringToData.swift in Sources */,
 				2632388626F2548600D72B43 /* DFUWithoutBLE.swift in Sources */,
 				26D7817326CAB27800BBF555 /* WatchNotificationsView.swift in Sources */,
@@ -520,7 +524,7 @@
 				263B20BC26CDF20400676BF0 /* BatteryChart.swift in Sources */,
 				2644261226DC093D009BD54A /* SetTime.swift in Sources */,
 				266F53E626FA7676007481A6 /* HomeScreen.swift in Sources */,
-				263B20B526CD673900676BF0 /* StatusViewTabs.swift in Sources */,
+				263B20B526CD673900676BF0 /* ChartTabs.swift in Sources */,
 				26D7816E26CA003B00BBF555 /* SettingsFunctions.swift in Sources */,
 				26A6316326C4C6D6005AE404 /* BLEConnectView.swift in Sources */,
 				26D7816526C9EB3800BBF555 /* BLEDelegates.swift in Sources */,

--- a/Infini-iOS.xcodeproj/project.pbxproj
+++ b/Infini-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		264BFE7826BCAAC00050A223 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 264BFE7726BCAAC00050A223 /* README.md */; };
 		264DB80B26C62ED600E812C3 /* SideMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264DB80A26C62ED600E812C3 /* SideMenu.swift */; };
 		264DB80D26C633CF00E812C3 /* PageSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264DB80C26C633CF00E812C3 /* PageSwitcher.swift */; };
+		266F53E426F7FCA6007481A6 /* ChartManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 266F53E326F7FCA6007481A6 /* ChartManager.swift */; };
 		2675CA5726DC447500967E4D /* SheetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5626DC447500967E4D /* SheetManager.swift */; };
 		2675CA5A26DC81AA00967E4D /* DFUComplete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2675CA5926DC81AA00967E4D /* DFUComplete.swift */; };
 		26A6314D26BEFD2C005AE404 /* MusicController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A6314C26BEFD2C005AE404 /* MusicController.swift */; };
@@ -104,6 +105,7 @@
 		264DB80A26C62ED600E812C3 /* SideMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenu.swift; sourceTree = "<group>"; };
 		264DB80C26C633CF00E812C3 /* PageSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSwitcher.swift; sourceTree = "<group>"; };
 		2656FD9A26D1B30C001EF20C /* PrivacyPolicy.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PrivacyPolicy.md; sourceTree = "<group>"; };
+		266F53E326F7FCA6007481A6 /* ChartManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartManager.swift; sourceTree = "<group>"; };
 		2675CA5626DC447500967E4D /* SheetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetManager.swift; sourceTree = "<group>"; };
 		2675CA5926DC81AA00967E4D /* DFUComplete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DFUComplete.swift; sourceTree = "<group>"; };
 		26A6314C26BEFD2C005AE404 /* MusicController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicController.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 			children = (
 				263B20B426CD673900676BF0 /* StatusViewTabs.swift */,
 				263B20B926CDF13400676BF0 /* HeartChart.swift */,
+				266F53E326F7FCA6007481A6 /* ChartManager.swift */,
 				263B20BB26CDF20400676BF0 /* BatteryChart.swift */,
 			);
 			path = "Status View Components";
@@ -490,6 +493,7 @@
 				2632388C26F265B100D72B43 /* MainView.swift in Sources */,
 				2632388826F2576D00D72B43 /* DFUFileSelectButton.swift in Sources */,
 				26F426EF26C72D7D00D0866B /* BLEStatusView.swift in Sources */,
+				266F53E426F7FCA6007481A6 /* ChartManager.swift in Sources */,
 				264BFE7426BC526C0050A223 /* BLEManager.swift in Sources */,
 				2632388E26F297CB00D72B43 /* OnboardingBody.swift in Sources */,
 				2644261626DC1D8E009BD54A /* Onboarding.swift in Sources */,

--- a/Infini-iOS/BLE/BLEDelegates.swift
+++ b/Infini-iOS/BLE/BLEDelegates.swift
@@ -72,15 +72,21 @@ extension BLEManager: CBPeripheralDelegate {
 			peripheral.setNotifyValue(true, for: characteristic)
 			let bpm = heartRate(from: characteristic)
 			heartBPM = Double(bpm)
-			if bpm != 0 {
-				hrmChartDataPoints.append(updateChartInfo(data: Double(bpm), heart: true))
+			if !chartReconnect {
+				if bpm != 0{
+					ChartManager.shared.addItem(dataPoint: DataPoint(date: Date(), value: Double(bpm), chart: ChartsAsInts.heart.rawValue))
+				}
+			} else {
+				// this skips the first HRM data point. With persistent data, every time there's an OOR condition, it copies the current HRM value, even if you've stopped the HRM. In testing I turned off the HRM, but stayed connected to the watch, and got probably 20 data points from the value the HRM was stopped at.
+				
+				chartReconnect = false
 			}
-			
 		case batCBUUID:
 			// subscribe to battery updates, read battery hex data, convert it to decimal
 			peripheral.setNotifyValue(true, for: characteristic)
 			let batData = [UInt8](characteristic.value!)
 			batChartDataPoints.append(updateChartInfo(data: Double(batData[0]), heart: false))
+			ChartManager.shared.addItem(dataPoint: DataPoint(date: Date(), value: Double(batData[0]), chart: ChartsAsInts.battery.rawValue))
 			batteryLevel = Double(batData[0])
 			
 			

--- a/Infini-iOS/BLE/BLEManager.swift
+++ b/Infini-iOS/BLE/BLEManager.swift
@@ -29,6 +29,23 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 		let deviceUUID: CBUUID
 	}
 	
+	struct cbuuidList {
+		static let shared = cbuuidList()
+		let hrm = CBUUID(string: "2A37")
+		let bat = CBUUID(string: "2A19")
+		let time = CBUUID(string: "2A2B")
+		let notify = CBUUID(string: "2A46")
+		let modelNumber = CBUUID(string: "2A24")
+		let serial = CBUUID(string: "2A25")
+		let firmware = CBUUID(string: "2A26")
+		let hardwareRevision = CBUUID(string: "2A27")
+		let softwareRevision = CBUUID(string: "2A28")
+		let manufacturer = CBUUID(string: "2A29")
+		let musicControl = CBUUID(string: "00000001-78FC-48FE-8E23-433B3A1942D0")
+		let musicTrack = CBUUID(string: "00000004-78FC-48FE-8E23-433B3A1942D0")
+		let musicArtist = CBUUID(string: "00000003-78FC-48FE-8E23-433B3A1942D0")
+	}
+	
 	@Published var musicChars = musicCharacteristics()
 	
 	let settings = UserDefaults.standard
@@ -57,14 +74,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 	var chartReconnect: Bool = true										// skip first HRM transmission on every fresh connection to prevent saving of BS data
 	
 	// declare some CBUUIDs for easier reference
-	let hrmCBUUID = CBUUID(string: "2A37")
-	let batCBUUID = CBUUID(string: "2A19")
-	let timeCBUUID = CBUUID(string: "2A2B")
-	let notifyCBUUID = CBUUID(string: "2A46")
-	let firmwareCBUUID = CBUUID(string: "2A26")
-	let musicControlCBUUID = CBUUID(string: "00000001-78FC-48FE-8E23-433B3A1942D0")
-	let musicTrackCBUUID = CBUUID(string: "00000004-78FC-48FE-8E23-433B3A1942D0")
-	let musicArtistCBUUID = CBUUID(string: "00000003-78FC-48FE-8E23-433B3A1942D0")
+
 	
 
 	

--- a/Infini-iOS/BLE/BLEManager.swift
+++ b/Infini-iOS/BLE/BLEManager.swift
@@ -39,7 +39,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 	@Published var isConnectedToPinetime = false						// another flag published to update UI stuff. Can probably be implemented better in the future
 	@Published var heartBPM: Double = 0									// published var to communicate the HRM data to the UI.
 	@Published var batteryLevel: Double = 0								// Same as heartBPM but for battery data
-	@Published var hrmChartDataPoints: [LineChartDataPoint] = []
+	//@Published var hrmChartDataPoints: [LineChartDataPoint] = []
 	@Published var batChartDataPoints: [LineChartDataPoint] = []
 	@Published var firmwareVersion: String = "Disconnected"
 	@Published var setTimeError = false
@@ -54,6 +54,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 	@Published var setAutoconnectUUID: String = ""							// placeholder for now while I figure out how to save the whole device in UserDefaults to save "favorite" devices
 	
 	var firstConnect: Bool = true										// makes iOS connected message only show up on first connect, not if device drops connection and reconnects
+	var chartReconnect: Bool = true										// skip first HRM transmission on every fresh connection to prevent saving of BS data
 	
 	// declare some CBUUIDs for easier reference
 	let hrmCBUUID = CBUUID(string: "2A37")
@@ -96,6 +97,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 			myCentral.cancelPeripheralConnection(infiniTime)
 			firstConnect = true
 			isConnectedToPinetime = false
+			chartReconnect = false
 		}
 	}
 	
@@ -163,6 +165,7 @@ class BLEManager: NSObject, ObservableObject, CBCentralManagerDelegate {
 	
 	func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
 		if error != nil {
+			chartReconnect = true
 			connect(peripheral: peripheral)
 		}
 	}

--- a/Infini-iOS/BLE/DeviceInfo.swift
+++ b/Infini-iOS/BLE/DeviceInfo.swift
@@ -1,0 +1,53 @@
+//
+//  DeviceInfo.swift
+//  DeviceInfo
+//
+//  Created by Alex Emry on 9/21/21.
+//
+
+import Foundation
+import CoreBluetooth
+
+struct BLEDeviceInfo {
+	static var shared = BLEDeviceInfo()
+	var modelNumber = ""
+	var serial = ""
+	var firmware = ""
+	var hardwareRevision = ""
+	var softwareRevision = ""
+	var manufacturer = ""
+}
+
+struct GetDeviceInfo {
+	
+	struct cbuuid {
+		let modelNumber = CBUUID(string: "2A24")
+		let serial = CBUUID(string: "2A25")
+		let firmware = CBUUID(string: "2A26")
+		let hardwareRevision = CBUUID(string: "2A27")
+		let softwareRevision = CBUUID(string: "2A28")
+		let manufacturer = CBUUID(string: "2A29")
+	}
+	let cbuuids = cbuuid()
+	
+	func updateInfo(characteristic: CBCharacteristic) {
+		guard let value = characteristic.value else { return }
+		
+		switch characteristic.uuid {
+		case cbuuids.modelNumber:
+			BLEDeviceInfo.shared.modelNumber = String(data: value, encoding: .utf8) ?? ""
+		case cbuuids.serial:
+			BLEDeviceInfo.shared.serial = String(data: value, encoding: .utf8) ?? ""
+		case cbuuids.firmware:
+			BLEDeviceInfo.shared.firmware = String(data: value, encoding: .utf8) ?? ""
+		case cbuuids.hardwareRevision:
+			BLEDeviceInfo.shared.hardwareRevision = String(data: value, encoding: .utf8) ?? ""
+		case cbuuids.softwareRevision:
+			BLEDeviceInfo.shared.softwareRevision = String(data: value, encoding: .utf8) ?? ""
+		case cbuuids.manufacturer:
+			BLEDeviceInfo.shared.manufacturer = String(data: value, encoding: .utf8) ?? ""
+		default:
+			break
+		}
+	}
+}

--- a/Infini-iOS/Infini_iOS.xcdatamodeld/Infini_iOS.xcdatamodel/contents
+++ b/Infini-iOS/Infini_iOS.xcdatamodeld/Infini_iOS.xcdatamodel/contents
@@ -6,7 +6,9 @@
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="value" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
     </entity>
+    <entity name="DeviceNames" representedClassName="DeviceNames" syncable="YES" codeGenerationType="class"/>
     <elements>
         <element name="ChartDataPoint" positionX="-63" positionY="-18" width="128" height="89"/>
+        <element name="DeviceNames" positionX="-54" positionY="18" width="128" height="29"/>
     </elements>
 </model>

--- a/Infini-iOS/Infini_iOS.xcdatamodeld/Infini_iOS.xcdatamodel/contents
+++ b/Infini-iOS/Infini_iOS.xcdatamodeld/Infini_iOS.xcdatamodel/contents
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19197" systemVersion="20G95" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ChartDataPoint" representedClassName="ChartDataPoint" syncable="YES" codeGenerationType="class">
+        <attribute name="chart" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="value" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
     </entity>
     <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="ChartDataPoint" positionX="-63" positionY="-18" width="128" height="89"/>
     </elements>
 </model>

--- a/Infini-iOS/Infini_iOSApp.swift
+++ b/Infini-iOS/Infini_iOSApp.swift
@@ -15,7 +15,6 @@ struct Infini_iOSApp: App {
         WindowGroup {
             ContentView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
-				.environmentObject(PageSwitcher())
 				.environmentObject(BLEManager())
 				.environmentObject(DFU_Updater())
         }

--- a/Infini-iOS/Persistence.swift
+++ b/Infini-iOS/Persistence.swift
@@ -14,8 +14,11 @@ struct PersistenceController {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
         for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+			let newitem = ChartDataPoint(context: viewContext)
+			newitem.timestamp = Date()
+			newitem.value = 10.0
+			newitem.id = UUID()
+			newitem.chart = ChartsAsInts.heart.rawValue
         }
         do {
             try viewContext.save()

--- a/Infini-iOS/View Components/BLEConnectView.swift
+++ b/Infini-iOS/View Components/BLEConnectView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct Connect: View {
 	
-	@EnvironmentObject var pageSwitcher: PageSwitcher
+	@ObservedObject var pageSwitcher: PageSwitcher = PageSwitcher.shared
 	@EnvironmentObject var bleManager: BLEManager
 	@Environment(\.presentationMode) var presentation
 	@State var scanOrStopScan: Bool = true
@@ -55,7 +55,6 @@ struct Connect: View {
 struct ConnectView_Previews: PreviewProvider {
 	static var previews: some View {
 		Connect()
-			.environmentObject(PageSwitcher())
 			.environmentObject(BLEManager())
 	}
 }

--- a/Infini-iOS/View Components/BLEStatusView.swift
+++ b/Infini-iOS/View Components/BLEStatusView.swift
@@ -11,48 +11,17 @@ import SwiftUI
 struct StatusView: View {
 	
 	@EnvironmentObject var bleManager: BLEManager
-	@EnvironmentObject var sheetManager: SheetManager
 	@Environment(\.colorScheme) var colorScheme
 	
 	var body: some View {
-		VStack (spacing: 10){
-			Text("Current Stats")
+		VStack {
+			Text("Graphs")
 				.font(.largeTitle)
 				.padding()
 				.frame(maxWidth: .infinity, alignment: .leading)
 			
 			Spacer()
-			if bleManager.isConnectedToPinetime {
-				StatusTabs().environmentObject(bleManager)
-
-				Button(action: {
-					self.bleManager.disconnect()
-				}) {
-					Text("Disconnect from PineTime")
-						.padding()
-						.padding(.vertical, 7)
-						.frame(maxWidth: .infinity, alignment: .center)
-						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
-						.foregroundColor(Color.white)
-						.cornerRadius(10)
-						.padding(.horizontal, 20)
-						.padding(.bottom)
-				}
-			} else {
-				Button(action: {
-					sheetManager.showSheet = true
-				}) {
-					Text("Connect to PineTime")
-						.padding()
-						.padding(.vertical, 7)
-						.frame(maxWidth: .infinity, alignment: .center)
-						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
-						.foregroundColor(Color.white)
-						.cornerRadius(10)
-						.padding(.horizontal, 20)
-						.padding(.bottom)
-				}
-			}
+			StatusTabs().environmentObject(bleManager)
 		}
 	}
 }

--- a/Infini-iOS/View Components/BLEStatusView.swift
+++ b/Infini-iOS/View Components/BLEStatusView.swift
@@ -32,7 +32,7 @@ struct StatusView: View {
 						.padding()
 						.padding(.vertical, 7)
 						.frame(maxWidth: .infinity, alignment: .center)
-						.background(colorScheme == .dark ? Color.darkGray : Color.lightGray)
+						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
 						.foregroundColor(Color.white)
 						.cornerRadius(10)
 						.padding(.horizontal, 20)
@@ -46,14 +46,14 @@ struct StatusView: View {
 						.padding()
 						.padding(.vertical, 7)
 						.frame(maxWidth: .infinity, alignment: .center)
-						.background(colorScheme == .dark ? Color.darkGray : Color.lightGray)
+						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
 						.foregroundColor(Color.white)
 						.cornerRadius(10)
 						.padding(.horizontal, 20)
 						.padding(.bottom)
 				}
 			}
-		}//.padding()
+		}
 	}
 }
 

--- a/Infini-iOS/View Components/BLEStatusView.swift
+++ b/Infini-iOS/View Components/BLEStatusView.swift
@@ -15,12 +15,11 @@ struct StatusView: View {
 	
 	var body: some View {
 		VStack {
-			Text("Graphs")
+			Text("Charts")
 				.font(.largeTitle)
 				.padding()
 				.frame(maxWidth: .infinity, alignment: .leading)
-			
-			Spacer()
+			TimeRangeTabs()
 			StatusTabs().environmentObject(bleManager)
 		}
 	}

--- a/Infini-iOS/View Components/HomeScreen.swift
+++ b/Infini-iOS/View Components/HomeScreen.swift
@@ -1,0 +1,71 @@
+//
+//  HomeScreen.swift
+//  HomeScreen
+//
+//  Created by Alex Emry on 9/21/21.
+//
+
+import Foundation
+import SwiftUI
+
+struct HomeScreen: View {
+	@EnvironmentObject var bleManager: BLEManager
+	@Environment(\.colorScheme) var colorScheme
+	@AppStorage("autoconnect") var autoconnect: Bool = false
+	
+	var body: some View{
+		VStack{
+			Text("Infini-iOS")
+				.font(.largeTitle)
+				.padding()
+				.frame(maxWidth: .infinity, alignment: .leading)
+			
+			Text("Firmware Version: " + BLEDeviceInfo.shared.firmware)
+				.font(.title)
+			Text("Model Number: " + BLEDeviceInfo.shared.modelNumber)
+				.font(.title)
+			Text("Software Revision: " + BLEDeviceInfo.shared.softwareRevision)
+				.font(.title)
+			Text("Hardware revision: " + BLEDeviceInfo.shared.hardwareRevision)
+				.font(.title)
+			Text("Manufacturer: " + BLEDeviceInfo.shared.manufacturer)
+				.font(.title)
+			Spacer()
+
+			
+			if bleManager.isConnectedToPinetime {
+				Button(action: {
+					self.bleManager.disconnect()
+				}) {
+					Text("Disconnect from PineTime")
+						.padding()
+						.padding(.vertical, 7)
+						.frame(maxWidth: .infinity, alignment: .center)
+						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
+						.foregroundColor(Color.white)
+						.cornerRadius(10)
+						.padding(.horizontal, 20)
+						.padding(.bottom)
+				}
+			} else {
+				Button(action: {
+					if !autoconnect{
+						SheetManager.shared.showSheet = true
+					} else {
+						bleManager.startScanning()
+					}
+				}) {
+					Text("Connect to PineTime")
+						.padding()
+						.padding(.vertical, 7)
+						.frame(maxWidth: .infinity, alignment: .center)
+						.background(colorScheme == .dark ? Color.darkGray : Color.gray)
+						.foregroundColor(Color.white)
+						.cornerRadius(10)
+						.padding(.horizontal, 20)
+						.padding(.bottom)
+				}.disabled(bleManager.isScanning)
+			}
+		}
+	}
+}

--- a/Infini-iOS/View Components/MainView.swift
+++ b/Infini-iOS/View Components/MainView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct MainView: View {
 
-	@EnvironmentObject var pageSwitcher: PageSwitcher
+	@ObservedObject var pageSwitcher: PageSwitcher = PageSwitcher.shared
 	@EnvironmentObject var bleManager: BLEManager
 	
 	
@@ -24,6 +24,8 @@ struct MainView: View {
 			StatusView()
 		case .settings:
 			Settings_Page()
+		case .home:
+			HomeScreen()
 		}
 	}
 }

--- a/Infini-iOS/View Components/Onboarding/OnboardingDismissButton.swift
+++ b/Infini-iOS/View Components/Onboarding/OnboardingDismissButton.swift
@@ -10,12 +10,12 @@
 import SwiftUI
 
 struct OnboardingDismissButton: View {
-	@EnvironmentObject var sheetManager: SheetManager
+	//@EnvironmentObject var sheetManager: SheetManager
 	@Environment(\.colorScheme) var colorScheme
 	
 	var body: some View{
 		Button(action: {
-			sheetManager.showSheet = false
+			SheetManager.shared.showSheet = false
 		}) {
 			Text("Dismiss")
 				.padding()

--- a/Infini-iOS/View Components/SettingsView.swift
+++ b/Infini-iOS/View Components/SettingsView.swift
@@ -21,6 +21,8 @@ struct Settings_Page: View {
 	@AppStorage("autoconnectUUID") var autoconnectUUID: String = "empty"
 	@AppStorage("heartChartFill") var heartChartFill: Bool = true
 	@AppStorage("batChartFill") var batChartFill: Bool = true
+	@FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ChartDataPoint.timestamp, ascending: true)])
+	private var chartPoints: FetchedResults<ChartDataPoint>
 	
 	var body: some View {
 		VStack (alignment: .leading){
@@ -36,19 +38,18 @@ struct Settings_Page: View {
 							print(autoconnectUUID)
 						} label: {
 							Text("Use Current Device for Autoconnect")
-								.foregroundColor(colorScheme == .dark ? Color.white : Color.black)
 						}
 						Button {
 							autoconnectUUID = ""
 							print(autoconnectUUID)
 						} label: {
 							Text("Clear Autoconnect Device")
-								.foregroundColor(colorScheme == .dark ? Color.white : Color.black)
 						}
 					}
 
 
 				}
+
 				Section(header: Text("Notifications")) {
 					Toggle("Enable Watch Notifications", isOn: $watchNotifications)
 					Toggle("Notify about Low Battery", isOn: $batteryNotification)
@@ -56,6 +57,18 @@ struct Settings_Page: View {
 				Section(header: Text("Graph Styles")) {
 					Toggle("Filled HRM Graph", isOn: $heartChartFill)
 					Toggle("Filled Battery Graph", isOn: $batChartFill)
+				}
+				Section(header: Text("Graph Data")) {
+					Button (action: {
+						ChartManager.shared.deleteAll(dataSet: chartPoints, chart: ChartsAsInts.battery.rawValue)
+					}) {
+						(Text("Clear All HRM Chart Data"))
+					}
+					Button (action: {
+						ChartManager.shared.deleteAll(dataSet: chartPoints, chart: ChartsAsInts.battery.rawValue)
+					}) {
+						(Text("Clear All Battery Chart Data"))
+					}
 				}
 				Section(header: Text("Links")) {
 					Link("Infini-iOS GitHub", destination: URL(string: "https://github.com/xan-m/Infini-iOS")!)

--- a/Infini-iOS/View Components/SideMenu.swift
+++ b/Infini-iOS/View Components/SideMenu.swift
@@ -38,7 +38,7 @@ struct SideMenu: View {
 					Image(systemName: "heart")
 						.foregroundColor(.gray)
 						.imageScale(.large)
-					Text("Graphs")
+					Text("Charts")
 						.foregroundColor(.gray)
 						.padding(5)
 				}

--- a/Infini-iOS/View Components/SideMenu.swift
+++ b/Infini-iOS/View Components/SideMenu.swift
@@ -10,9 +10,8 @@ import SwiftUI
 struct SideMenu: View {
 	
 	@Binding var isOpen: Bool
-	@EnvironmentObject var pageSwitcher: PageSwitcher
+	@ObservedObject var pageSwitcher: PageSwitcher = PageSwitcher.shared
 	@EnvironmentObject var bleManager: BLEManager
-	@EnvironmentObject var sheetManager: SheetManager
 	
 	func changePage(newPage: Page){
 		withAnimation{
@@ -24,16 +23,27 @@ struct SideMenu: View {
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack {
-				Button(action: {changePage(newPage: .status)}) {
-					Image(systemName: "heart")
+				Button(action: {changePage(newPage: .home)}) {
+					Image(systemName: "house.fill")
 						.foregroundColor(.gray)
 						.imageScale(.large)
-					Text("Current Stats")
+					Text("Home")
 						.foregroundColor(.gray)
 						.padding(5)
 				}
 			}
 				.padding(.top, 100)
+			HStack {
+				Button(action: {changePage(newPage: .status)}) {
+					Image(systemName: "heart")
+						.foregroundColor(.gray)
+						.imageScale(.large)
+					Text("Graphs")
+						.foregroundColor(.gray)
+						.padding(5)
+				}
+			}
+				.padding(.top, 20)
 			HStack {
 				Button(action: {changePage(newPage: .dfu)}) {
 					Image(systemName: "arrow.up.doc")
@@ -61,7 +71,7 @@ struct SideMenu: View {
 			HStack {
 				if !self.bleManager.isConnectedToPinetime {
 					Button(action: {
-						sheetManager.showSheet = true
+						SheetManager.shared.showSheet = true
 						pageSwitcher.showMenu = false
 					}) {
 						Image(systemName: "radiowaves.right")

--- a/Infini-iOS/View Components/Status View Components/BatteryChart.swift
+++ b/Infini-iOS/View Components/Status View Components/BatteryChart.swift
@@ -28,30 +28,12 @@ struct BatteryChart: View {
 	
 	
 	var body: some View {
-		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
+		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 0), topLine: .maximum(of: 100))
 		let data = LineChartData(dataSets: LineDataSet(
 			dataPoints: ChartManager.shared.convert(results: chartPoints),
 			style: setLineStyle()),
 			chartStyle: chartStyle
 		)
-		
-		Button (action: {
-			ChartManager.shared.deleteAll(dataSet: chartPoints)
-		}) {
-			(Text("Delete All Entries"))
-		}
-		Button (action: {
-			var newDelete: [ChartDataPoint] = []
-			for i in chartPoints{
-				if i.timestamp!.timeIntervalSinceNow <= -3600 {
-					newDelete.append(i)
-				}
-			}
-			print(String(newDelete.count))
-			ChartManager.shared.deleteItems(dataSet: newDelete)
-		}) {
-			(Text("Delete Entries Over 1 Hour Old"))
-		}
 		
 		if chartPoints.count > 1 {
 			if batChartFill {

--- a/Infini-iOS/View Components/Status View Components/BatteryChart.swift
+++ b/Infini-iOS/View Components/Status View Components/BatteryChart.swift
@@ -14,6 +14,9 @@ import SwiftUICharts
 struct BatteryChart: View {
 	@EnvironmentObject var bleManager: BLEManager
 	@AppStorage("batChartFill") var batChartFill: Bool = true
+	@Environment(\.managedObjectContext) var viewContext
+	@FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ChartDataPoint.timestamp, ascending: true)])
+	private var chartPoints: FetchedResults<ChartDataPoint>
 	
 	func setLineStyle() -> LineStyle {
 		if batChartFill {
@@ -25,33 +28,34 @@ struct BatteryChart: View {
 	
 	
 	var body: some View {
-		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 0), topLine: .maximum(of: 100))
+		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
 		let data = LineChartData(dataSets: LineDataSet(
-										dataPoints: bleManager.batChartDataPoints,
-										style: setLineStyle()),
-									chartStyle: chartStyle
-								 )
+			dataPoints: ChartManager.shared.convert(results: chartPoints, chart: ChartsAsInts.battery.rawValue),
+			style: setLineStyle()),
+			chartStyle: chartStyle
+		)
 		
-		if bleManager.batChartDataPoints.count > 1 {
+		if chartPoints.count > 1 {
 			if batChartFill {
 				FilledLineChart(chartData: data)
 					.animation(.easeIn)
 					.floatingInfoBox(chartData: data)
 					.touchOverlay(chartData: data, unit: .suffix(of: "%"))
 					.yAxisLabels(chartData: data)
+					.padding()
 			} else {
 				LineChart(chartData: data)
 					.animation(.easeIn)
 					.floatingInfoBox(chartData: data)
 					.touchOverlay(chartData: data, unit: .suffix(of: "%"))
 					.yAxisLabels(chartData: data)
-
+					.padding()
 			}
 		} else {
 			VStack (alignment: .center) {
 				Spacer()
 				HStack (alignment: .center) {
-					Text("Waiting for Data")
+					Text("Insufficient Battery Data")
 						.font(.title)
 				}
 				Spacer()

--- a/Infini-iOS/View Components/Status View Components/ChartManager.swift
+++ b/Infini-iOS/View Components/Status View Components/ChartManager.swift
@@ -38,25 +38,39 @@ class ChartManager {
 		newItem.chart = dataPoint.chart
 		do {
 			try viewContext.save()
-			if newItem.chart == ChartsAsInts.heart.rawValue {
-				print("hrm save successful")
-			} else {
-				print("batt save successful")
-			}
 		} catch {
-			//fatalError(error.localizedDescription)
-			print(error)
+			print(error.localizedDescription)
 		}
 	}
 	
-	func convert(results: FetchedResults<ChartDataPoint>, chart: Int16) -> [LineChartDataPoint] {
+	func deleteAll(dataSet: FetchedResults<ChartDataPoint>) {
+		for i in dataSet {
+			viewContext.delete(i)
+		}
+		do {
+			try viewContext.save()
+		} catch {
+			print(error.localizedDescription)
+		}
+	}
+	
+	func deleteItems(dataSet: [ChartDataPoint]) {
+		for i in dataSet {
+			viewContext.delete(i)
+		}
+		do {
+			try viewContext.save()
+		} catch {
+			print(error.localizedDescription)
+		}
+	}
+	
+	func convert(results: FetchedResults<ChartDataPoint>) -> [LineChartDataPoint] {
 		var dataPoints: [LineChartDataPoint] = []
 		let dateFormat = DateFormatter()
 		dateFormat.dateFormat = "H:mm:ss"
 		for data in results {
-			if data.chart == chart {
-				dataPoints.append(LineChartDataPoint(value: data.value, xAxisLabel: "Time", description: dateFormat.string(from: data.timestamp!), date: data.timestamp!))
-			}
+			dataPoints.append(LineChartDataPoint(value: data.value, xAxisLabel: "Time", description: dateFormat.string(from: data.timestamp!), date: data.timestamp!))
 		}
 		return dataPoints
 	}

--- a/Infini-iOS/View Components/Status View Components/ChartManager.swift
+++ b/Infini-iOS/View Components/Status View Components/ChartManager.swift
@@ -1,0 +1,64 @@
+//
+//  ChartManager.swift
+//  ChartManager
+//
+//  Created by Alex Emry on 9/19/21.
+//
+
+import Foundation
+import SwiftUI
+import CoreData
+
+import SwiftUICharts
+
+enum ChartsAsInts: Int16 {
+	case heart = 0
+	case battery = 1
+}
+
+struct DataPoint {
+	let date: Date
+	let value: Double
+	let chart: Int16
+}
+
+class ChartManager {
+	
+	static let shared = ChartManager()
+	private init() {}
+	
+	//@Environment(\.managedObjectContext) var viewContext
+	let viewContext = PersistenceController.shared.container.viewContext
+	
+	func addItem(dataPoint: DataPoint) {
+		let newItem = ChartDataPoint(context: viewContext)
+		newItem.timestamp = dataPoint.date
+		newItem.value = dataPoint.value
+		newItem.id = UUID()
+		newItem.chart = dataPoint.chart
+		do {
+			try viewContext.save()
+			if newItem.chart == ChartsAsInts.heart.rawValue {
+				print("hrm save successful")
+			} else {
+				print("batt save successful")
+			}
+		} catch {
+			//fatalError(error.localizedDescription)
+			print(error)
+		}
+	}
+	
+	func convert(results: FetchedResults<ChartDataPoint>, chart: Int16) -> [LineChartDataPoint] {
+		var dataPoints: [LineChartDataPoint] = []
+		let dateFormat = DateFormatter()
+		dateFormat.dateFormat = "H:mm:ss"
+		for data in results {
+			if data.chart == chart {
+				dataPoints.append(LineChartDataPoint(value: data.value, xAxisLabel: "Time", description: dateFormat.string(from: data.timestamp!), date: data.timestamp!))
+			}
+		}
+		return dataPoints
+	}
+	
+}

--- a/Infini-iOS/View Components/Status View Components/ChartTabs.swift
+++ b/Infini-iOS/View Components/Status View Components/ChartTabs.swift
@@ -13,17 +13,16 @@ import SwiftUI
 struct StatusTabs: View {
 	
 	@EnvironmentObject var bleManager: BLEManager
-	@State var trueIfHeart = true
-	@State var trueIfBat = false
 	@Environment(\.colorScheme) var colorScheme
 	@AppStorage("lastStatusViewWasHeart") var lastStatusViewWasHeart: Bool = false
+	@ObservedObject var chartManager = ChartManager.shared
 
 	var body: some View{
 		VStack {
 			HStack {
 				Button (action: {
-					self.trueIfHeart = true
-					self.trueIfBat = false
+					chartManager.trueIfHeart = true
+					chartManager.trueIfBat = false
 					lastStatusViewWasHeart = true
 				}) {
 				(Text(Image(systemName: "heart"))
@@ -35,13 +34,13 @@ struct StatusTabs: View {
 					.font(.body))
 					.frame(maxWidth:.infinity, alignment: .center)
 					.padding()
-					.background(colorScheme == .dark ? (trueIfHeart ? Color.darkGray : Color.darkestGray) : (trueIfHeart ? Color.gray : Color.lightGray))
+					.background(colorScheme == .dark ? (chartManager.trueIfHeart ? Color.darkGray : Color.darkestGray) : (chartManager.trueIfHeart ? Color.gray : Color.lightGray))
 					.cornerRadius(5)
 					.font(.title)
 				}.padding(.leading, 10)
 				Button (action: {
-					self.trueIfHeart = false
-					self.trueIfBat = true
+					chartManager.trueIfHeart = false
+					chartManager.trueIfBat = true
 					lastStatusViewWasHeart = false
 				}) {
 				(Text(Image(systemName: "battery.100"))
@@ -50,7 +49,7 @@ struct StatusTabs: View {
 					.foregroundColor(Color.white))
 					.frame(maxWidth: .infinity, alignment: .center)
 					.padding()
-					.background(colorScheme == .dark ? (trueIfBat ? Color.darkGray : Color.darkestGray) : (trueIfBat ? Color.gray : Color.lightGray))
+					.background(colorScheme == .dark ? (chartManager.trueIfBat ? Color.darkGray : Color.darkestGray) : (chartManager.trueIfBat ? Color.gray : Color.lightGray))
 					.cornerRadius(5)
 					.font(.title)
 				}
@@ -59,14 +58,14 @@ struct StatusTabs: View {
 			if lastStatusViewWasHeart {
 				HeartChart()
 					.onAppear() {
-						self.trueIfHeart = true
-						self.trueIfBat = false
+						chartManager.trueIfHeart = true
+						chartManager.trueIfBat = false
 					}
 			} else {
 				BatteryChart()
 					.onAppear() {
-						self.trueIfHeart = false
-						self.trueIfBat = true
+						chartManager.trueIfHeart = false
+						chartManager.trueIfBat = true
 					}
 			}
 		}

--- a/Infini-iOS/View Components/Status View Components/HeartChart.swift
+++ b/Infini-iOS/View Components/Status View Components/HeartChart.swift
@@ -14,6 +14,7 @@ import CoreData
 
 struct HeartChart: View {
 	@EnvironmentObject var bleManager: BLEManager
+	@ObservedObject var chartManager = ChartManager.shared
 	@AppStorage("heartChartFill") var heartChartFill: Bool = true
 	@Environment(\.managedObjectContext) var viewContext
 	@Environment(\.colorScheme) var colorScheme
@@ -30,29 +31,13 @@ struct HeartChart: View {
 
 	
 	var body: some View {
-		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, /*infoBoxBackgroundColour: (colorScheme == .dark ? Color.gray : Color.lightGray), */baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
+		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
 		let data = LineChartData(dataSets: LineDataSet(
 			dataPoints: ChartManager.shared.convert(results: chartPoints),
 			style: setLineStyle()),
 			chartStyle: chartStyle
 		)
-		Button (action: {
-			ChartManager.shared.deleteAll(dataSet: chartPoints)
-		}) {
-			(Text("Delete All Entries"))
-		}
-		Button (action: {
-			var newDelete: [ChartDataPoint] = []
-			for i in chartPoints{
-				if i.timestamp!.timeIntervalSinceNow <= -3600 {
-					newDelete.append(i)
-				}
-			}
-			print(String(newDelete.count))
-			ChartManager.shared.deleteItems(dataSet: newDelete)
-		}) {
-			(Text("Delete Entries Over 1 Hour Old"))
-		}
+		
 		if chartPoints.count > 1 {
 			if heartChartFill {
 				FilledLineChart(chartData: data)

--- a/Infini-iOS/View Components/Status View Components/HeartChart.swift
+++ b/Infini-iOS/View Components/Status View Components/HeartChart.swift
@@ -10,13 +10,14 @@
 import Foundation
 import SwiftUI
 import SwiftUICharts
+import CoreData
 
 struct HeartChart: View {
 	@EnvironmentObject var bleManager: BLEManager
 	@AppStorage("heartChartFill") var heartChartFill: Bool = true
 	@Environment(\.managedObjectContext) var viewContext
 	@Environment(\.colorScheme) var colorScheme
-	@FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ChartDataPoint.timestamp, ascending: true)])
+	@FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ChartDataPoint.timestamp, ascending: true)], predicate: NSPredicate(format: "chart == 0"))
 	private var chartPoints: FetchedResults<ChartDataPoint>
 	
 	func setLineStyle() -> LineStyle {
@@ -31,10 +32,27 @@ struct HeartChart: View {
 	var body: some View {
 		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, /*infoBoxBackgroundColour: (colorScheme == .dark ? Color.gray : Color.lightGray), */baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
 		let data = LineChartData(dataSets: LineDataSet(
-			dataPoints: ChartManager.shared.convert(results: chartPoints, chart: ChartsAsInts.heart.rawValue),
+			dataPoints: ChartManager.shared.convert(results: chartPoints),
 			style: setLineStyle()),
 			chartStyle: chartStyle
 		)
+		Button (action: {
+			ChartManager.shared.deleteAll(dataSet: chartPoints)
+		}) {
+			(Text("Delete All Entries"))
+		}
+		Button (action: {
+			var newDelete: [ChartDataPoint] = []
+			for i in chartPoints{
+				if i.timestamp!.timeIntervalSinceNow <= -3600 {
+					newDelete.append(i)
+				}
+			}
+			print(String(newDelete.count))
+			ChartManager.shared.deleteItems(dataSet: newDelete)
+		}) {
+			(Text("Delete Entries Over 1 Hour Old"))
+		}
 		if chartPoints.count > 1 {
 			if heartChartFill {
 				FilledLineChart(chartData: data)

--- a/Infini-iOS/View Components/Status View Components/HeartChart.swift
+++ b/Infini-iOS/View Components/Status View Components/HeartChart.swift
@@ -5,7 +5,7 @@
 //  Created by Alex Emry on 8/18/21.
 //  
 //
-    
+
 
 import Foundation
 import SwiftUI
@@ -14,9 +14,11 @@ import SwiftUICharts
 struct HeartChart: View {
 	@EnvironmentObject var bleManager: BLEManager
 	@AppStorage("heartChartFill") var heartChartFill: Bool = true
+	@Environment(\.managedObjectContext) var viewContext
+	@Environment(\.colorScheme) var colorScheme
+	@FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \ChartDataPoint.timestamp, ascending: true)])
+	private var chartPoints: FetchedResults<ChartDataPoint>
 	
-	//let lineStyle: LineStyle!
-
 	func setLineStyle() -> LineStyle {
 		if heartChartFill {
 			return LineStyle(lineColour: ColourStyle(colours: [Color.red.opacity(0.7), Color.red.opacity(0.3)], startPoint: .top, endPoint: .bottom), lineType: .curvedLine, ignoreZero: false)
@@ -24,36 +26,37 @@ struct HeartChart: View {
 			return LineStyle(lineColour: ColourStyle(colour: Color.red), lineType: .curvedLine, ignoreZero: false)
 		}
 	}
-	
 
 	
 	var body: some View {
-		
-		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
+		let chartStyle = LineChartStyle(infoBoxPlacement: .floating, /*infoBoxBackgroundColour: (colorScheme == .dark ? Color.gray : Color.lightGray), */baseline: .minimumWithMaximum(of: 50), topLine: .maximum(of: 160))
 		let data = LineChartData(dataSets: LineDataSet(
-										dataPoints: bleManager.hrmChartDataPoints,
-										style: setLineStyle()),
-									chartStyle: chartStyle
-								 )
-		if bleManager.hrmChartDataPoints.count > 1 {
+			dataPoints: ChartManager.shared.convert(results: chartPoints, chart: ChartsAsInts.heart.rawValue),
+			style: setLineStyle()),
+			chartStyle: chartStyle
+		)
+		if chartPoints.count > 1 {
 			if heartChartFill {
 				FilledLineChart(chartData: data)
 					.animation(.easeIn)
 					.floatingInfoBox(chartData: data)
 					.touchOverlay(chartData: data, unit: .suffix(of: "BPM"))
 					.yAxisLabels(chartData: data)
+					.padding()
+				
 			} else {
 				LineChart(chartData: data)
 					.animation(.easeIn)
 					.floatingInfoBox(chartData: data)
 					.touchOverlay(chartData: data, unit: .suffix(of: "BPM"))
 					.yAxisLabels(chartData: data)
+					.padding()
 			}
 		} else {
 			VStack (alignment: .center) {
 				Spacer()
 				HStack (alignment: .center) {
-					Text("Waiting for Data")
+					Text("Insufficient Heart Rate Data")
 						.font(.title)
 				}
 				Spacer()

--- a/Infini-iOS/View Components/Status View Components/StatusViewTabs.swift
+++ b/Infini-iOS/View Components/Status View Components/StatusViewTabs.swift
@@ -29,7 +29,10 @@ struct StatusTabs: View {
 				(Text(Image(systemName: "heart"))
 					.foregroundColor(Color.pink) +
 				Text(": " + String(format: "%.0f", bleManager.heartBPM))
-					.foregroundColor(Color.white))
+					.foregroundColor(Color.white) +
+				Text(" BPM")
+					.foregroundColor(Color.white)
+					.font(.body))
 					.frame(maxWidth:.infinity, alignment: .center)
 					.padding()
 					.background(colorScheme == .dark ? (trueIfHeart ? Color.darkGray : Color.darkestGray) : (trueIfHeart ? Color.gray : Color.lightGray))
@@ -43,7 +46,7 @@ struct StatusTabs: View {
 				}) {
 				(Text(Image(systemName: "battery.100"))
 					.foregroundColor(Color.green) +
-					Text(": " + String(format: "%.0f", bleManager.batteryLevel))
+					Text(": " + String(format: "%.0f", bleManager.batteryLevel) + "%")
 					.foregroundColor(Color.white))
 					.frame(maxWidth: .infinity, alignment: .center)
 					.padding()

--- a/Infini-iOS/View Components/Status View Components/TimeRangeTabs.swift
+++ b/Infini-iOS/View Components/Status View Components/TimeRangeTabs.swift
@@ -1,0 +1,75 @@
+//
+//  TimeRangeTabs.swift
+//  TimeRangeTabs
+//
+//  Created by Alex Emry on 9/21/21.
+//
+
+import Foundation
+import SwiftUI
+
+//
+//  StatusViewTabs.swift
+//  Infini-iOS
+//
+//  Created by Alex Emry on 8/18/21.
+//
+//
+	
+
+import Foundation
+import SwiftUI
+
+struct TimeRangeTabs: View {
+	
+	@EnvironmentObject var bleManager: BLEManager
+	@ObservedObject var chartManager = ChartManager.shared
+	@Environment(\.colorScheme) var colorScheme
+	@AppStorage("lastStatusViewWasHeart") var lastStatusViewWasHeart: Bool = false
+
+	var body: some View{
+		HStack {
+			// set date range to last hour
+			Button (action: {
+				chartManager.dateRange = .hour
+			}) {
+			(Text("Hour")
+				.foregroundColor(Color.white))
+				.frame(maxWidth: .infinity, alignment: .center)
+				.padding()
+				.background(colorScheme == .dark ? (chartManager.dateRange == .hour ? Color.darkGray : Color.darkestGray) : (chartManager.dateRange == .hour ? Color.gray : Color.lightGray))
+				.cornerRadius(5)
+				.font(.title)
+			}
+			.padding(.leading, 10)
+			
+			// set date range to 24 hours
+			Button (action: {
+				chartManager.dateRange = .day
+			}) {
+			(Text("Day")
+				.foregroundColor(Color.white))
+				.frame(maxWidth: .infinity, alignment: .center)
+				.padding()
+				.background(colorScheme == .dark ? (chartManager.dateRange == .day ? Color.darkGray : Color.darkestGray) : (chartManager.dateRange == .day ? Color.gray : Color.lightGray))
+				.cornerRadius(5)
+				.font(.title)
+			}
+			.padding(.horizontal, 3)
+			
+			// set date range to last week
+			Button (action: {
+				chartManager.dateRange = .week
+			}) {
+			(Text("Week")
+				.foregroundColor(Color.white))
+				.frame(maxWidth: .infinity, alignment: .center)
+				.padding()
+				.background(colorScheme == .dark ? (chartManager.dateRange == .week ? Color.darkGray : Color.darkestGray) : (chartManager.dateRange == .week ? Color.gray : Color.lightGray))
+				.cornerRadius(5)
+				.font(.title)
+			}
+			.padding(.trailing, 10)
+		}
+	}
+}

--- a/Infini-iOS/View Components/View Utilities/PageSwitcher.swift
+++ b/Infini-iOS/View Components/View Utilities/PageSwitcher.swift
@@ -11,12 +11,16 @@ enum Page {
 	case dfu
 	case status
 	case settings
+	case home
 }
 
 class PageSwitcher: ObservableObject {
+	static let shared = PageSwitcher()
 	
-	@Published var currentPage: Page = .status
+	@Published var currentPage: Page = .home
 	@Published var connectViewLoad: Bool = false
 	@Published var showMenu: Bool = false
 	
 }
+
+

--- a/Infini-iOS/View Components/View Utilities/SheetManager.swift
+++ b/Infini-iOS/View Components/View Utilities/SheetManager.swift
@@ -16,6 +16,7 @@ enum SheetSelection {
 }
 
 class SheetManager: ObservableObject {
+	static let shared = SheetManager()
 		
 	@Published var showSheet: Bool = false
 	var sheetSelection: SheetSelection!

--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
 # Infini-iOS - an InfiniTime Companion App for iOS
 
-This is an alpha-verging-on-beta iOS application that allows you to interact with your PineTime running (at least) InfiniTime 1.3.0 (and perhaps other watches/OSes, pending testing).
+This iOS application allows you to interact with your PineTime smartwatch running InfiniTime (and perhaps other watches/OSes, pending testing).
 
 ### What works:
-- Scan nearby devices and allow the user to select an InfiniTime device to connect to
-- Connect to a PineTime running InfiniTime 1.3.0
+- Scan nearby devices and connect to PineTimes
 - Set time and date immediately after connection
-- Read heart rate, and subscribe to HRM's notifier for updated values
-- Read battery level, and subscribe to battery level's notifier for updated values
-- Display heart rate, battery level, and connection/bluetooth/scanning status to app main page
-- Music controls on InfiniTime can control Apple Music. I can't access system-level music controls or system volume from within an app, so the controls literally only work on Apple Music.
-- DFU - updates to InfiniTime, bootloader, and recovery firmware have all been successful in testing
-- Limited user-configurable settings. I'm counting on testers to let me know what other things should be optional preferences!
+- Read and chart battery level data and heart rate data from watch
+- Music controls on InfiniTime can control Apple Music.
+- DFU - send firmware updates to the PineTime
 
 ### What doesn't work:
-- Navigation app.
-- Music controls for anything other than Apple Music -- This requires Apple Music Service (AMS) to be implemented in InfiniTime. Once I feel like Infini-iOS has reached a semi-stable state, I'll try to help implement this service!
-- Phone notifications pushing to watch -- This requires a proprietary Apple service that behaves in more or less the exact same way as the notification service already implemented in InfiniTime, but this one has Apple in the name... as with AMS, I'll work on getting this implemented in Infini-iOS once I feel like the app is stable enough to leave alone for a while
+- InfiniTime's navigation app. As far as I can tell, there is no API in Swift to access current directions, so this will likely never work unless it's added into a mapping application.
+- Music controls for anything other than Apple Music -- This requires Apple Music Service (AMS) to be implemented in InfiniTime.
+- Phone notifications pushing to watch -- This requires a proprietary Apple service as well.
 
 ### How to try it out:
 Join the TestFlight beta now! Click this link from your iOS device: https://testflight.apple.com/join/Z7u1Jxp4
@@ -25,8 +21,3 @@ Join the TestFlight beta now! Click this link from your iOS device: https://test
 I'm not interested in profiting from this app, but the Apple Developer License was not cheap! If you've enjoyed the app and have some disposable income, consider donating. If not, no problem!
 
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/alexemry)
-
-XMR: 45k5KTyKgEBbKxUFqzHMAgZPHZeHDGQ7zCBuJqumHaTZHFFdj98KAen4MK4JsAUwEWW1xS13J7VY4SmNguyeBEvb296nske
-
-### Disclaimer
-**This is the first time I've worked with Swift, SwiftUI, XCode, BLE, or anything else in this application. I take no responsibility for what happens if you interact with this repository in any way. If it breaks your phone, your watch, or your brain,** ***that's on you buddy!***


### PR DESCRIPTION
Graph persistence is finally here! I'm going to merge this very soon because the work here is starting to bleed over into UI changes for the whole app and the core functionality of persistence is working great.

This branch enables the following:
- Reading, writing, and deleting graph data points from persistent storage
- Filtering graph data points (within the last hour, day, or week)
- A new "Home" view that will act as the new landing page when you open the app. This view will feature the connect/disconnect button at the bottom and some handy info about your PineTime. It's not much yet, but I wanted get the connect/disconnect button off of the charts view to free up some room for the filtering buttons.

This PR will close issue #15, and is the major landmark before 0.9.0! 